### PR TITLE
Remove unnecessary escapes

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,9 @@ module.exports = function(md, options) {
   try {
     if (options.stripListLeaders) {
       if (options.listUnicodeChar)
-        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, options.listUnicodeChar + ' $1');
+        output = output.replace(/^([\s\t]*)([*\-+]|\d+\.)\s+/gm, options.listUnicodeChar + ' $1');
       else
-        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, '$1');
+        output = output.replace(/^([\s\t]*)([*\-+]|\d+\.)\s+/gm, '$1');
     }
     if (options.gfm) {
       output = output
@@ -57,14 +57,14 @@ module.exports = function(md, options) {
       // Remove HTML tags
       .replace(htmlReplaceRegex, '')
       // Remove setext-style headers
-      .replace(/^[=\-]{2,}\s*$/g, '')
+      .replace(/^[=-]{2,}\s*$/g, '')
       // Remove footnotes?
-      .replace(/\[\^.+?\](\: .*?$)?/g, '')
+      .replace(/\[\^.+?\](: .*?$)?/g, '')
       .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
       // Remove images
-      .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, options.useImgAltText ? '$1' : '')
+      .replace(/!\[(.*?)\][[(].*?[\])]/g, options.useImgAltText ? '$1' : '')
       // Remove inline links
-      .replace(/\[([^\]]*?)\][\[\(].*?[\]\)]/g, options.replaceLinksWithURL ? '$2' : '$1')
+      .replace(/\[([^\]]*?)\][[(].*?[\])]/g, options.replaceLinksWithURL ? '$2' : '$1')
       // Remove blockquotes
       .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
       // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')
@@ -73,7 +73,7 @@ module.exports = function(md, options) {
       // Remove atx-style headers
       .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
       // Remove * emphasis
-      .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
+      .replace(/([*]+)(\S)(.*?\S)??\1/g, '$2$3')
       // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if 
       //   1. Either there is a whitespace character before opening _ and after closing _.
       //   2. Or _ is at the start/end of the string.


### PR DESCRIPTION
I used the ESLint rule [`no-useless-escape`](https://eslint.org/docs/latest/rules/no-useless-escape) to highlight unnecessary escapes in the Regex. You can also see [this Stack Overflow answer](https://stackoverflow.com/a/400316/8839059) for more details on characters that need to be escaped and those that do not need to be escaped when inside character classes.

I also noticed that the `should still remove escaped markdown syntax` test is not working correctly, because the string `\# Heading in _italic_` is interpreted as `# Heading in _italic_`, and if you add double backslashes in the beginning (`\\# Heading in _italic_`) the test fails. You can see more details about using backslashes in strings [here](https://stackoverflow.com/a/10042082/8839059).

If you want me to add ESLint as a development dependency to the project, with the `no-useless-escape` rule as the only active rule, let me know.