### PR TITLE
Add prefix string to error log

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ module.exports = function(md, options) {
       // Replace strike through
       .replace(/~(.*?)~/g, '$1');
   } catch(e) {
-    console.error(e);
+    console.error("remove-markdown encountered error: %s", e);
     return md;
   }
   return output;

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = function(md, options) {
   options.abbr = options.hasOwnProperty('abbr') ? options.abbr : false;
   options.replaceLinksWithURL = options.hasOwnProperty('replaceLinksWithURL') ? options.replaceLinksWithURL : false;
   options.htmlTagsToSkip = options.hasOwnProperty('htmlTagsToSkip') ? options.htmlTagsToSkip : [];
+  options.throwError = options.hasOwnProperty('throwError') ? options.throwError : false;
 
   var output = md || '';
 
@@ -89,6 +90,8 @@ module.exports = function(md, options) {
       // Replace strike through
       .replace(/~(.*?)~/g, '$1');
   } catch(e) {
+    if (options.throwError) throw e;
+
     console.error("remove-markdown encountered error: %s", e);
     return md;
   }


### PR DESCRIPTION
This PR adds prefix string when error is encountered.

In elk, we sometimes saw the follwing:
```
 TypeError: removeMarkdown(...).substr is not a function
```
It might be possible that `removeMarkdown` wasn't able to parse the argument.

However, there is not much clue what error happened.

With the error prefix, it would be easier to find the cause.