### PR TITLE
fix: correct module hint of built-in typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,13 +1,11 @@
-declare module "remove-markdown" {
-  export function removeMd(md: string, options?: {
-    stripListLeaders?: boolean;
-    listUnicodeChar?: string;
-    gfm?: boolean;
-    useImgAltText: boolean;
-    abbr?: boolean;
-    replaceLinksWithURL?: boolean;
-    htmlTagsToSkip?: string[];
-  }): string;
+declare function removeMd(md: string, options?: {
+  stripListLeaders?: boolean;
+  listUnicodeChar?: string;
+  gfm?: boolean;
+  useImgAltText: boolean;
+  abbr?: boolean;
+  replaceLinksWithURL?: boolean;
+  htmlTagsToSkip?: string[];
+}): string;
 
-  export = removeMd;
-}
+export = removeMd;


### PR DESCRIPTION
a module cannot be declare as both commonjs (the `export =` syntax) and esm (the `export function ...`).

without this patch, typescript errors with: `An export assignment cannot be used in a module with other exported elements.ts(2309)`

in addition, there's no need to `declare module "remove-markdown"`, as this is not an ambient definition, and matches the file next to it inside the `remove-markdown` package.

with this patch everything works properly again. tested locally.

note: this also matches how `@types/remove-markdown` was declaring things: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/remove-markdown/index.d.ts