### PR TITLE
Prepare 0.7.0-rc.0 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: npm
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
+
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: Use a trusted-publishing-compatible npm version
+        run: npm install --global npm@11.9.0
+
+      - name: Validate release source and select the npm dist-tag
+        env:
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          git merge-base --is-ancestor HEAD origin/main
+          node <<'NODE'
+            const { appendFileSync } = require('node:fs');
+            const { version } = require('./package.json');
+            const isPrerelease = version.includes('-');
+            if (version !== process.env.RELEASE_TAG) {
+              throw new Error(
+                'Release tag ' + process.env.RELEASE_TAG +
+                ' does not match package version ' + version,
+              );
+            }
+            if (isPrerelease !== (process.env.RELEASE_PRERELEASE === 'true')) {
+              throw new Error('GitHub release prerelease status does not match the package version');
+            }
+            const distTag = isPrerelease ? 'next' : 'latest';
+            appendFileSync(process.env.GITHUB_ENV, 'NPM_DIST_TAG=' + distTag + '\n');
+          NODE
+
+      - run: npm ci
+      - run: npm run prepublishOnly
+      - run: npm run test:differential
+      - run: npm run test:bundlers
+      - run: npm run test:deno
+      - run: npm run test:deno:package
+      - run: npm publish --tag "${NPM_DIST_TAG}" --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remove-markdown",
-  "version": "0.6.4",
+  "version": "0.7.0-rc.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remove-markdown",
-      "version": "0.6.4",
+      "version": "0.7.0-rc.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-markdown",
-  "version": "0.6.4",
+  "version": "0.7.0-rc.0",
   "description": "Remove Markdown formatting from text",
   "type": "commonjs",
   "main": "./index.js",
@@ -37,7 +37,7 @@
     "test": "mocha -R spec test/remove-markdown.js",
     "test:modules": "node --test test/modules.test.mjs",
     "test:package": "node --test test/package.test.mjs",
-    "test:types": "node --test test/types.test.mjs && attw --pack . --entrypoints . ./index ./index.js ./package.json",
+    "test:types": "node --test test/types.test.mjs",
     "test:differential": "node --test test/differential.test.mjs",
     "test:bundlers": "node --test test/bundlers.test.mjs",
     "test:deno": "deno test test/deno.test.mjs",
@@ -46,7 +46,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/zuchka/remove-markdown.git"
+    "url": "git+https://github.com/zuchka/remove-markdown.git"
   },
   "keywords": [
     "markdown"

--- a/test/helpers/package-fixture.mjs
+++ b/test/helpers/package-fixture.mjs
@@ -54,8 +54,34 @@ export function installRegistryPackage(consumer, specifier) {
   );
 }
 
-export function run(command, args, cwd) {
-  execFileSync(command, args, { cwd, stdio: 'pipe' });
+export function run(command, args, cwd, options = {}) {
+  execFileSync(command, args, { cwd, stdio: 'pipe', ...options });
+}
+
+export function runAttw(cwd) {
+  const attwRoot = dirname(require.resolve('@arethetypeswrong/cli/package.json'));
+  run(
+    process.execPath,
+    [
+      join(attwRoot, 'dist', 'index.js'),
+      '--pack',
+      '.',
+      '--entrypoints',
+      '.',
+      './index',
+      './index.js',
+      './package.json',
+    ],
+    cwd,
+    {
+      env: {
+        ...process.env,
+        npm_config_dry_run: 'false',
+        npm_config_json: 'false',
+      },
+      stdio: 'inherit',
+    },
+  );
 }
 
 export function runNode(filename, cwd) {
@@ -70,6 +96,11 @@ function runNpm(args, cwd, options = {}) {
 
   return execFileSync(command[0], command[1], {
     cwd,
+    env: {
+      ...process.env,
+      npm_config_dry_run: 'false',
+      npm_config_json: 'false',
+    },
     stdio: options.encoding ? ['ignore', 'pipe', 'pipe'] : 'pipe',
     ...options,
   });

--- a/test/types.test.mjs
+++ b/test/types.test.mjs
@@ -6,6 +6,8 @@ import test from 'node:test';
 import {
   installPackedPackage,
   packProject,
+  projectRoot,
+  runAttw,
   runTypeScript,
   writeJson,
   writeText,
@@ -110,4 +112,8 @@ removeMd('text', { htmlTagsToSkip: [1] });
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }
+});
+
+test('the package entry points pass Are the Types Wrong validation', () => {
+  runAttw(projectRoot);
 });


### PR DESCRIPTION
## Summary

- bump package and lockfile metadata to `0.7.0-rc.0`
- add an npm Trusted Publishing workflow gated by the GitHub `npm` environment
- verify that release tags match the package version, prerelease state, and a commit on `main`
- publish prereleases to `next` and stable releases to `latest`
- make nested package and type checks meaningful when invoked by `npm publish --dry-run`
- canonicalize the repository URL used for npm provenance

No package is published by this PR. The publishing workflow runs only after a GitHub release is published and then waits for approval through the `npm` environment.

## Verification

- `npm ci` and `npm audit`: zero vulnerabilities
- `npm publish --dry-run --tag next --access public`: passed without warnings
- existing behavior and packed CommonJS/ESM tests: passed
- TypeScript consumer compilation and Are the Types Wrong: passed
- differential comparison against published 0.6.4: passed
- esbuild and Rollup consumers: passed
- Deno source and packed-package checks: passed
- release workflow validation and actionlint: passed

The dry-run artifact contains the expected seven files and reports:

- package: `remove-markdown@0.7.0-rc.0`
- packed size: 4,519 bytes
- integrity: `sha512-azpkjtazriq0EgapkKDGPf+Ap0Goet+ZDcY+iLXwXk73f/sNT2gYUwxpwNm3ZYUwh2KR6IpPtlN4r/BWm9WJwA==`

## Required after merge, before creating the release

- [ ] Create a GitHub environment named `npm` with manual approval
- [ ] Configure the npm trusted publisher for `zuchka/remove-markdown`, workflow `publish.yml`, environment `npm`, with `npm publish` permission
- [ ] Create a GitHub prerelease/tag named `0.7.0-rc.0`
- [ ] Approve the `npm` environment deployment and verify `next` points to `0.7.0-rc.0` while `latest` remains `0.6.4`
