### PR TITLE
Fix native browser ESM loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to this project will be documented in this file.
 
 - Added conditional package exports for CommonJS, ES modules, and their matching type declarations.
 
+### Fixed
+
+- Made the ES module entry self-contained so it works when loaded directly by browsers and URL-based module loaders without CommonJS interop.
+
 ESM and Deno support was originally proposed in [#116](https://github.com/zuchka/remove-markdown/pull/116) by [@tukkek](https://github.com/tukkek).
 
 ## [0.6.3] - 2026-01-14

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ const markdown = '# This is a heading\n\nThis is a paragraph with [a link](http:
 const plainText = removeMd(markdown);
 ```
 
+### Browser ES modules
+
+The ESM entry is self-contained and can be loaded directly from a CDN that
+serves JavaScript with the correct MIME type. Pin the URL to the version you
+have tested:
+
+```html
+<script type="module">
+  import removeMd from 'https://unpkg.com/remove-markdown@0.7.0/index.mjs';
+
+  const plainText = removeMd('# This is a heading');
+</script>
+```
+
 ### Deno
 
 ```js
@@ -43,7 +57,7 @@ const markdown = '# This is a heading\n\nThis is a paragraph with [a link](http:
 const plainText = removeMd(markdown);
 ```
 
-Deno support is provided through the npm package; there is no separate JSR package. The package exposes one callable default export in every runtime. Named exports and direct imports from raw GitHub URLs are not supported.
+Deno support is provided through the npm package; there is no separate JSR package. The package exposes one callable default export in every runtime. Named exports and direct imports from raw GitHub URLs, which do not reliably serve the correct JavaScript MIME type, are not supported.
 
 You can also supply an options object to the function. Currently, the following options are supported:
 

--- a/index.mjs
+++ b/index.mjs
@@ -1,3 +1,99 @@
-import removeMarkdown from './index.js';
+// Generated from index.js by scripts/build-esm.mjs. Do not edit directly.
 
-export default removeMarkdown;
+export default function removeMarkdown(md, options) {
+  options = options || {};
+  options.listUnicodeChar = options.hasOwnProperty('listUnicodeChar') ? options.listUnicodeChar : false;
+  options.stripListLeaders = options.hasOwnProperty('stripListLeaders') ? options.stripListLeaders : true;
+  options.gfm = options.hasOwnProperty('gfm') ? options.gfm : true;
+  options.useImgAltText = options.hasOwnProperty('useImgAltText') ? options.useImgAltText : true;
+  options.abbr = options.hasOwnProperty('abbr') ? options.abbr : false;
+  options.replaceLinksWithURL = options.hasOwnProperty('replaceLinksWithURL') ? options.replaceLinksWithURL : false;
+  options.separateLinksAndTexts = options.hasOwnProperty('separateLinksAndTexts') ? options.separateLinksAndTexts : null;
+  options.htmlTagsToSkip = options.hasOwnProperty('htmlTagsToSkip') ? options.htmlTagsToSkip : [];
+  options.throwError = options.hasOwnProperty('throwError') ? options.throwError : false;
+
+  var output = md || '';
+
+  // Remove horizontal rules (stripListHeaders conflict with this rule, which is why it has been moved to the top)
+  output = output.replace(/^ {0,3}((?:-[\t ]*){3,}|(?:_[ \t]*){3,}|(?:\*[ \t]*){3,})(?:\n+|$)/gm, '');
+
+  try {
+    if (options.stripListLeaders) {
+      if (options.listUnicodeChar)
+        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, options.listUnicodeChar + ' $1');
+      else
+        output = output.replace(/^([\s\t]*)([\*\-\+]|\d+\.)\s+/gm, '$1');
+    }
+    if (options.gfm) {
+      output = output
+      // Header
+        .replace(/\n={2,}/g, '\n')
+        // Fenced codeblocks
+        .replace(/~{3}.*\n/g, '')
+        // Strikethrough
+        .replace(/~~/g, '')
+        // Fenced codeblocks with backticks
+        .replace(/```(?:.*)\n([\s\S]*?)```/g, (_, code) => code.trim());
+    }
+    if (options.abbr) {
+      // Remove abbreviations
+      output = output.replace(/\*\[.*\]:.*\n/, '');
+    }
+
+    let htmlReplaceRegex = /<[^>]*>/g
+    if (options.htmlTagsToSkip && options.htmlTagsToSkip.length > 0) {
+      // Create a regex that matches tags not in htmlTagsToSkip
+      const joinedHtmlTagsToSkip = options.htmlTagsToSkip.join('|')
+      htmlReplaceRegex = new RegExp(
+        `<(?!\/?(${joinedHtmlTagsToSkip})(?=>|\s[^>]*>))[^>]*>`,
+        'g',
+      )
+    }
+
+    if (options.separateLinksAndTexts) {
+      output = output.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '$1' + options.separateLinksAndTexts + '$2');
+    }
+
+    output = output
+      // Remove HTML tags
+      .replace(htmlReplaceRegex, '')
+      // Remove setext-style headers
+      .replace(/^[=\-]{2,}\s*$/g, '')
+      // Remove footnotes?
+      .replace(/\[\^.+?\](\: .*?$)?/g, '')
+      .replace(/\s{0,2}\[.*?\]: .*?$/g, '')
+      // Remove images
+      .replace(/\!\[(.*?)\][\[\(].*?[\]\)]/g, options.useImgAltText ? '$1' : '')
+      // Remove inline links
+      .replace(/\[([\s\S]*?)\]\s*[\(\[](.*?)[\)\]]/g, options.replaceLinksWithURL ? '$2' : '$1')
+      // Remove blockquotes
+      .replace(/^(\n)?\s{0,3}>\s?/gm, '$1')
+      // .replace(/(^|\n)\s{0,3}>\s?/g, '\n\n')
+      // Remove reference-style links?
+      .replace(/^\s{1,2}\[(.*?)\]: (\S+)( ".*?")?\s*$/g, '')
+      // Remove atx-style headers
+      .replace(/^(\n)?\s{0,}#{1,6}\s*( (.+))? +#+$|^(\n)?\s{0,}#{1,6}\s*( (.+))?$/gm, '$1$3$4$6')
+      // Remove * emphasis
+      .replace(/([\*]+)(\S)(.*?\S)??\1/g, '$2$3')
+      // Remove _ emphasis. Unlike *, _ emphasis gets rendered only if
+      //   1. Either there is a whitespace character before opening _ and after closing _.
+      //   2. Or _ is at the start/end of the string.
+      .replace(/(^|\W)([_]+)(\S)(.*?\S)??\2($|\W)/g, '$1$3$4$5')
+      // Remove single-line code blocks (already handled multiline above in gfm section)
+      .replace(/(`{3,})(.*?)\1/gm, '$2')
+      // Remove inline code
+      .replace(/`(.+?)`/g, '$1')
+      // // Replace two or more newlines with exactly two? Not entirely sure this belongs here...
+      // .replace(/\n{2,}/g, '\n\n')
+      // // Remove newlines in a paragraph
+      // .replace(/(\S+)\n\s*(\S+)/g, '$1 $2')
+      // Replace strike through
+      .replace(/~(.*?)~/g, '$1');
+  } catch(e) {
+    if (options.throwError) throw e;
+
+    console.error("remove-markdown encountered error: %s", e);
+    return md;
+  }
+  return output;
+};

--- a/index.node.mjs
+++ b/index.node.mjs
@@ -1,0 +1,3 @@
+import removeMarkdown from './index.js';
+
+export default removeMarkdown;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     ".": {
       "import": {
         "types": "./index.d.mts",
+        "browser": "./index.mjs",
+        "node": "./index.node.mjs",
         "default": "./index.mjs"
       },
       "require": {
@@ -19,6 +21,10 @@
     },
     "./index": "./index.js",
     "./index.js": "./index.js",
+    "./index.mjs": {
+      "types": "./index.d.mts",
+      "default": "./index.mjs"
+    },
     "./index.d.mts": "./index.d.mts",
     "./index.d.ts": "./index.d.ts",
     "./LICENSE": "./LICENSE",
@@ -28,21 +34,24 @@
   "files": [
     "index.js",
     "index.mjs",
+    "index.node.mjs",
     "index.d.ts",
     "index.d.mts",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
+    "build:esm": "node scripts/build-esm.mjs",
+    "check:esm": "node scripts/build-esm.mjs --check",
     "test": "mocha -R spec test/remove-markdown.js",
     "test:modules": "node --test test/modules.test.mjs",
     "test:package": "node --test test/package.test.mjs",
     "test:types": "node --test test/types.test.mjs",
     "test:differential": "node --test test/differential.test.mjs",
     "test:bundlers": "node --test test/bundlers.test.mjs",
-    "test:deno": "deno test test/deno.test.mjs",
+    "test:deno": "deno test --no-lock --allow-import=127.0.0.1 --allow-net=127.0.0.1 --allow-read test/deno.test.mjs",
     "test:deno:package": "node --test test/deno-package.test.mjs",
-    "prepublishOnly": "npm test && npm run test:modules && npm run test:package && npm run test:types"
+    "prepublishOnly": "npm run check:esm && npm test && npm run test:modules && npm run test:package && npm run test:types"
   },
   "repository": {
     "type": "git",

--- a/scripts/build-esm.mjs
+++ b/scripts/build-esm.mjs
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const commonJsEntry = new URL('../index.js', import.meta.url);
+const esmEntry = new URL('../index.mjs', import.meta.url);
+const assignment = 'module.exports = function(md, options) {';
+const declaration = 'export default function removeMarkdown(md, options) {';
+const generatedNotice =
+  '// Generated from index.js by scripts/build-esm.mjs. Do not edit directly.\n\n';
+
+const commonJsSource = readFileSync(commonJsEntry, 'utf8');
+const assignmentCount = commonJsSource.split(assignment).length - 1;
+
+if (assignmentCount !== 1) {
+  throw new Error(
+    `Expected exactly one CommonJS export assignment, found ${assignmentCount}`,
+  );
+}
+
+const expectedEsmSource =
+  generatedNotice + commonJsSource.replace(assignment, declaration);
+
+if (process.argv.includes('--check')) {
+  const actualEsmSource = readFileSync(esmEntry, 'utf8');
+
+  if (actualEsmSource !== expectedEsmSource) {
+    throw new Error(
+      'index.mjs is out of date. Run `npm run build:esm` and commit the result.',
+    );
+  }
+} else {
+  writeFileSync(esmEntry, expectedEsmSource);
+}

--- a/test/bundlers.test.mjs
+++ b/test/bundlers.test.mjs
@@ -1,6 +1,7 @@
+import assert from 'node:assert/strict';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import test from 'node:test';
 
 import commonjs from '@rollup/plugin-commonjs';
@@ -38,13 +39,20 @@ if (actual !== 'Bundled output') {
 `,
     );
 
-    await build({
+    const esbuildResult = await build({
       bundle: true,
       entryPoints: [entry],
       format: 'esm',
+      metafile: true,
       outfile: join(consumer, 'esbuild-output.mjs'),
       platform: 'browser',
     });
+    const esbuildInputs = Object.keys(esbuildResult.metafile.inputs).map(
+      (path) => basename(path),
+    );
+    assert.ok(esbuildInputs.includes('index.mjs'));
+    assert.ok(!esbuildInputs.includes('index.node.mjs'));
+    assert.ok(!esbuildInputs.includes('index.js'));
     runNode('esbuild-output.mjs', consumer);
 
     const bundle = await rollup({
@@ -52,6 +60,10 @@ if (actual !== 'Bundled output') {
       plugins: [nodeResolve(), commonjs()],
     });
     try {
+      const rollupInputs = bundle.watchFiles.map((path) => basename(path));
+      assert.ok(rollupInputs.includes('index.mjs'));
+      assert.ok(!rollupInputs.includes('index.node.mjs'));
+      assert.ok(!rollupInputs.includes('index.js'));
       await bundle.write({
         file: join(consumer, 'rollup-output.mjs'),
         format: 'esm',

--- a/test/deno-package.test.mjs
+++ b/test/deno-package.test.mjs
@@ -24,6 +24,7 @@ test('Deno checks and executes the packed npm package', () => {
     writeText(
       join(consumer, 'consumer.test.mjs'),
       `import removeMd from 'remove-markdown';
+import removeMdFromIndexMjs from 'remove-markdown/index.mjs';
 
 Deno.test('the installed package works', () => {
   const actual = removeMd('**bold** and [link](https://example.com)');
@@ -31,6 +32,9 @@ Deno.test('the installed package works', () => {
 
   if (actual !== expected) {
     throw new Error(\`Expected \${JSON.stringify(expected)}, got \${JSON.stringify(actual)}\`);
+  }
+  if (removeMdFromIndexMjs('~~portable~~') !== 'portable') {
+    throw new Error('The explicit ESM entry returned unexpected output');
   }
 });
 `,

--- a/test/deno.test.mjs
+++ b/test/deno.test.mjs
@@ -8,3 +8,44 @@ Deno.test('the ESM entry works in Deno', () => {
     throw new Error(`Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
   }
 });
+
+Deno.test('the ESM entry works as a self-contained URL module', async () => {
+  const esmSource = await Deno.readTextFile(new URL('../index.mjs', import.meta.url));
+  const requestedPaths = [];
+  const server = Deno.serve(
+    {
+      hostname: '127.0.0.1',
+      port: 0,
+      onListen() {},
+    },
+    (request) => {
+      const { pathname } = new URL(request.url);
+      requestedPaths.push(pathname);
+
+      if (pathname !== '/index.mjs') {
+        return new Response('Not found', { status: 404 });
+      }
+
+      return new Response(esmSource, {
+        headers: { 'content-type': 'text/javascript; charset=utf-8' },
+      });
+    },
+  );
+
+  try {
+    const moduleUrl =
+      `http://127.0.0.1:${server.addr.port}/index.mjs?test=${crypto.randomUUID()}`;
+    const { default: removeMarkdown } = await import(moduleUrl);
+
+    if (removeMarkdown('# URL-loaded **module**') !== 'URL-loaded module') {
+      throw new Error('The URL-loaded ESM entry returned unexpected output');
+    }
+    if (requestedPaths.length !== 1 || requestedPaths[0] !== '/index.mjs') {
+      throw new Error(
+        `The ESM entry loaded unexpected dependencies: ${JSON.stringify(requestedPaths)}`,
+      );
+    }
+  } finally {
+    await server.shutdown();
+  }
+});

--- a/test/differential.test.mjs
+++ b/test/differential.test.mjs
@@ -5,6 +5,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 
+import candidateEsm from '../index.mjs';
+
 import {
   installPackedPackage,
   installRegistryPackage,
@@ -99,10 +101,17 @@ test('the candidate matches published 0.6.4 behavior', () => {
 
     for (const input of inputs) {
       for (const options of optionSets) {
+        const expected = baseline(input, cloneOptions(options));
+
         assert.equal(
           candidate(input, cloneOptions(options)),
-          baseline(input, cloneOptions(options)),
-          `Output differed for ${JSON.stringify({ input, options })}`,
+          expected,
+          `CommonJS output differed for ${JSON.stringify({ input, options })}`,
+        );
+        assert.equal(
+          candidateEsm(input, cloneOptions(options)),
+          expected,
+          `ESM output differed for ${JSON.stringify({ input, options })}`,
         );
       }
     }

--- a/test/helpers/package-fixture.mjs
+++ b/test/helpers/package-fixture.mjs
@@ -15,6 +15,7 @@ export const expectedPackageFiles = [
   'index.d.ts',
   'index.js',
   'index.mjs',
+  'index.node.mjs',
   'package.json',
 ];
 
@@ -60,10 +61,20 @@ export function run(command, args, cwd, options = {}) {
 
 export function runAttw(cwd) {
   const attwRoot = dirname(require.resolve('@arethetypeswrong/cli/package.json'));
+  const attwEntry = join(attwRoot, 'dist', 'index.js');
+  const options = {
+    env: {
+      ...process.env,
+      npm_config_dry_run: 'false',
+      npm_config_json: 'false',
+    },
+    stdio: 'inherit',
+  };
+
   run(
     process.execPath,
     [
-      join(attwRoot, 'dist', 'index.js'),
+      attwEntry,
       '--pack',
       '.',
       '--entrypoints',
@@ -73,14 +84,21 @@ export function runAttw(cwd) {
       './package.json',
     ],
     cwd,
-    {
-      env: {
-        ...process.env,
-        npm_config_dry_run: 'false',
-        npm_config_json: 'false',
-      },
-      stdio: 'inherit',
-    },
+    options,
+  );
+  run(
+    process.execPath,
+    [
+      attwEntry,
+      '--pack',
+      '.',
+      '--profile',
+      'esm-only',
+      '--entrypoints',
+      './index.mjs',
+    ],
+    cwd,
+    options,
   );
 }
 

--- a/test/modules.test.mjs
+++ b/test/modules.test.mjs
@@ -3,14 +3,41 @@ import { createRequire } from 'node:module';
 import test from 'node:test';
 
 import removeMd from 'remove-markdown';
+import removeMdFromPortableEsm from 'remove-markdown/index.mjs';
+
+import { projectRoot, run } from './helpers/package-fixture.mjs';
 
 const require = createRequire(import.meta.url);
 
 test('CommonJS and ESM expose the same function', async () => {
   const commonJs = require('remove-markdown');
   const dynamicImport = await import('remove-markdown');
+  const portableDynamicImport = await import('remove-markdown/index.mjs');
 
   assert.strictEqual(removeMd, commonJs);
   assert.strictEqual(dynamicImport.default, commonJs);
+  assert.strictEqual(portableDynamicImport.default, removeMdFromPortableEsm);
   assert.equal(removeMd('# Heading'), 'Heading');
+  assert.equal(removeMdFromPortableEsm('# Heading'), 'Heading');
+});
+
+test('the portable ESM implementation matches the CommonJS implementation', () => {
+  const commonJs = require('remove-markdown');
+  const cases = [
+    ['**bold** and _italic_', undefined],
+    ['[link](https://example.com)', { replaceLinksWithURL: true }],
+    ['![alt](image.png)', { useImgAltText: false }],
+    ['<span>kept</span><em>removed</em>', { htmlTagsToSkip: ['span'] }],
+  ];
+
+  for (const [markdown, options] of cases) {
+    assert.equal(
+      removeMdFromPortableEsm(markdown, options),
+      commonJs(markdown, options),
+    );
+  }
+});
+
+test('the generated ESM implementation is synchronized with index.js', () => {
+  run(process.execPath, ['scripts/build-esm.mjs', '--check'], projectRoot);
 });

--- a/test/package.test.mjs
+++ b/test/package.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -38,6 +38,10 @@ const packageMetadata = require('remove-markdown/package.json');
 assert.strictEqual(removeMd, removeMdFromIndex);
 assert.strictEqual(removeMd, removeMdFromIndexJs);
 assert.equal(packageMetadata.name, 'remove-markdown');
+assert.deepEqual(packageMetadata.exports['./index.mjs'], {
+  types: './index.d.mts',
+  default: './index.mjs',
+});
 assert.equal(removeMd('# Heading'), 'Heading');
 assert.equal(
   removeMd('[link](https://example.com)', { separateLinksAndTexts: ': ' }),
@@ -64,6 +68,7 @@ import { createRequire } from 'node:module';
 import removeMd from 'remove-markdown';
 import removeMdFromIndex from 'remove-markdown/index';
 import removeMdFromIndexJs from 'remove-markdown/index.js';
+import removeMdFromIndexMjs from 'remove-markdown/index.mjs';
 
 const require = createRequire(import.meta.url);
 const commonJs = require('remove-markdown');
@@ -74,10 +79,32 @@ assert.strictEqual(dynamicImport.default, commonJs);
 assert.strictEqual(removeMdFromIndex, commonJs);
 assert.strictEqual(removeMdFromIndexJs, commonJs);
 assert.equal(removeMd('**bold**'), 'bold');
+assert.equal(removeMdFromIndexMjs('**bold**'), 'bold');
 assert.equal(removeMd('![alt](image.png)', { useImgAltText: false }), '');
 `,
     );
     runNode('consumer.mjs', esmConsumer);
+
+    const nativeUrlConsumer = join(temporaryDirectory, 'native-url-consumer');
+    mkdirSync(nativeUrlConsumer);
+    writeText(join(nativeUrlConsumer, 'package.json'), '{"type":"module"}\n');
+    copyFileSync(
+      join(esmConsumer, 'node_modules', 'remove-markdown', 'index.mjs'),
+      join(nativeUrlConsumer, 'index.mjs'),
+    );
+    copyFileSync(
+      join(esmConsumer, 'node_modules', 'remove-markdown', 'index.js'),
+      join(nativeUrlConsumer, 'index.js'),
+    );
+    writeText(
+      join(nativeUrlConsumer, 'consumer.mjs'),
+      `import assert from 'node:assert/strict';
+import removeMd from './index.mjs';
+
+assert.equal(removeMd('# Native **ESM**'), 'Native ESM');
+`,
+    );
+    runNode('consumer.mjs', nativeUrlConsumer);
   } finally {
     rmSync(temporaryDirectory, { recursive: true, force: true });
   }

--- a/test/types.test.mjs
+++ b/test/types.test.mjs
@@ -80,6 +80,7 @@ removeMd('text', { gfm: 'yes' });
       `import removeMd from 'remove-markdown';
 import removeMdFromIndex from 'remove-markdown/index';
 import removeMdFromIndexJs from 'remove-markdown/index.js';
+import removeMdFromIndexMjs from 'remove-markdown/index.mjs';
 
 const output: string = removeMd('[link](https://example.com)', {
   stripListLeaders: false,
@@ -94,9 +95,11 @@ const output: string = removeMd('[link](https://example.com)', {
 });
 const indexOutput: string = removeMdFromIndex('**bold**');
 const indexJsOutput: string = removeMdFromIndexJs('_italic_');
+const indexMjsOutput: string = removeMdFromIndexMjs('~~struck~~');
 void output;
 void indexOutput;
 void indexJsOutput;
+void indexMjsOutput;
 
 // @ts-expect-error Markdown input must be a string.
 removeMd({});


### PR DESCRIPTION
## Summary

- make `index.mjs` a self-contained native ES module that works in browsers and URL-based module loaders
- preserve Node CommonJS/ESM function identity through a Node-specific ESM compatibility wrapper
- expose the explicit `remove-markdown/index.mjs` subpath with matching ESM declarations
- generate the portable ESM implementation from the canonical CommonJS source and fail tests if they drift
- document direct browser ESM usage and the supported CDN/MIME-type boundary

## Problem

The `0.7.0-rc.0` ESM entry imported its default export from `index.js`. Package-aware Node and Deno npm resolution treated that file as CommonJS and worked, but native browser and remote URL loaders parsed it as ESM and failed with:

> The requested module './index.js' does not provide an export named 'default'

This follow-up to #119 removes that dependency from the portable ESM entry while retaining the established CommonJS behavior and Node interop.

## Compatibility design

- `index.js` remains the canonical, unchanged CommonJS implementation.
- `index.mjs` is generated as a self-contained ESM implementation.
- `index.node.mjs` remains a thin CommonJS interop wrapper for normal Node package imports.
- Browser-aware resolvers select `index.mjs`; Node selects `index.node.mjs`.
- The generation check runs during `prepublishOnly` and the module test suite.

## Validation

- 39 existing behavior tests
- module and packed-tarball tests on Node 18, 20, 22, 24, and 26
- real-browser unbundled `index.mjs` import
- Deno 2.9.5 local, HTTP URL-module, and packed npm-package tests
- TypeScript 4.7, 5.9, and 7 NodeNext consumers
- Are the Types Wrong validation, including the explicit ESM-only entry
- esbuild and Rollup browser-condition selection and runtime checks
- pnpm 11.5, Yarn 4.18 Plug'n'Play, and Bun 1.4 consumers
- 22,330 CommonJS/ESM differential assertions against published `0.6.4`
- successful npm publish dry run
- zero production audit findings

## Rollout

`0.7.0-rc.0` is already published and immutable. After this merges, the next prerelease should be published as `0.7.0-rc.1` under the `next` dist-tag and receive a short browser-focused soak before promotion.

Performance issue #118 remains separate.
