### PR TITLE
Prepare 0.7.0-rc.1 release candidate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remove-markdown",
-  "version": "0.7.0-rc.0",
+  "version": "0.7.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remove-markdown",
-      "version": "0.7.0-rc.0",
+      "version": "0.7.0-rc.1",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-markdown",
-  "version": "0.7.0-rc.0",
+  "version": "0.7.0-rc.1",
   "description": "Remove Markdown formatting from text",
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
## Summary

- bump `package.json` from `0.7.0-rc.0` to `0.7.0-rc.1`
- keep the root package-lock metadata synchronized
- prepare the browser-native ESM fix from #122 for prerelease publication

## Validation

- `npm ci`
- version consistency check across `package.json` and `package-lock.json`
- complete `prepublishOnly` gate
- CommonJS, ESM, packed-package, and TypeScript tests
- Are the Types Wrong validation
- `npm publish --dry-run --tag next --access public`
- zero production audit findings

The dry-run tarball contains the expected eight files and identifies itself as `remove-markdown@0.7.0-rc.1`.

## After merge

Publish a GitHub prerelease tagged `0.7.0-rc.1` from the merged commit. The release event will trigger `.github/workflows/publish.yml`, which will publish the package under npm's `next` dist-tag. This PR itself does not publish anything.
