### PR TITLE
Prepare remove-markdown 0.7.0 stable release

### DIFF
--- a/.github/release-notes/0.7.0.md
+++ b/.github/release-notes/0.7.0.md
@@ -1,0 +1,121 @@
+# remove-markdown 0.7.0: CommonJS, native ESM, and Deno support
+
+`remove-markdown` 0.7.0 modernizes how the package can be loaded while preserving the CommonJS API used by existing applications.
+
+The package now supports CommonJS and ES modules in Node.js, native browser ES modules, and Deno 2 through npm compatibility. It also ships module-specific TypeScript declarations and an explicit export map for predictable resolution across runtimes and tooling.
+
+## Highlights
+
+- Native ES module support for Node.js and browsers
+- Existing CommonJS usage remains supported and behavior-compatible
+- Deno 2 support through `npm:remove-markdown`
+- Matching TypeScript declarations for CommonJS and ESM consumers
+- Explicit package exports for the root API, established deep imports, declarations, metadata, README, and license
+- Browser-aware and Node-aware entry selection
+- No runtime dependencies
+
+## Usage
+
+### CommonJS
+
+Existing CommonJS consumers can continue using the package without changing their imports:
+
+```js
+const removeMarkdown = require('remove-markdown');
+
+const plainText = removeMarkdown('# A **Markdown** heading');
+// A Markdown heading
+```
+
+### Node.js ES modules
+
+ESM projects can use a native default import:
+
+```js
+import removeMarkdown from 'remove-markdown';
+
+const plainText = removeMarkdown('# A **Markdown** heading');
+// A Markdown heading
+```
+
+### Browser ES modules
+
+The ESM entry is self-contained, so it can be loaded directly from a CDN that serves JavaScript with the correct MIME type. Pin browser imports to a version you have tested:
+
+```html
+<script type="module">
+  import removeMarkdown from 'https://unpkg.com/remove-markdown@0.7.0/index.mjs';
+
+  const plainText = removeMarkdown('# A **Markdown** heading');
+</script>
+```
+
+### Deno 2
+
+Deno users can import the npm package directly:
+
+```js
+import removeMarkdown from 'npm:remove-markdown@^0.7.0';
+
+const plainText = removeMarkdown('# A **Markdown** heading');
+// A Markdown heading
+```
+
+There is no separate JSR package. Direct imports from raw GitHub URLs are not supported because those URLs do not reliably use the required JavaScript MIME type.
+
+## Compatibility and migration
+
+No application-level migration is expected for existing CommonJS users. The implementation and callable default API remain compatible with 0.6.4, and established imports such as `remove-markdown/index` and `remove-markdown/index.js` remain available.
+
+The package exposes one callable default export. Named exports are not part of the API.
+
+Node package imports retain CommonJS/ESM function identity through a Node-specific compatibility entry. Browser-aware tools select the self-contained ESM implementation instead. A generation check keeps the CommonJS and ESM implementations synchronized.
+
+## Release hardening
+
+The 0.7 release went through two prerelease candidates:
+
+- `0.7.0-rc.0` introduced dual CommonJS/ESM packaging and Deno support.
+- Community testing found that its thin ESM wrapper depended on Node's CommonJS interoperability and therefore failed when `index.mjs` was loaded directly by a browser or URL-based module loader.
+- `0.7.0-rc.1` made the ESM entry self-contained, added explicit native-module regression coverage, and completed a multi-day soak without additional compatibility reports.
+
+That prerelease feedback prevented the browser-loading problem from reaching npm's `latest` tag.
+
+## Validation
+
+The 0.7 release process included:
+
+- the existing 39-test behavior suite
+- CommonJS, ESM, and packed-tarball tests on Node.js 18, 20, 22, 24, and 26
+- native unbundled browser and HTTP URL-module imports
+- Deno 2 source, URL-module, and packed npm-package tests
+- TypeScript NodeNext consumers and Are the Types Wrong validation
+- esbuild, Rollup, and Vite browser-targeted consumers
+- npm, pnpm, Yarn Plug'n'Play, and Bun installs
+- 11,165 representative and generated input/option combinations, comparing both new entry points with published 0.6.4 behavior
+- downstream builds and test suites for representative CommonJS and ESM projects
+- zero production audit findings
+
+## Scope
+
+This release changes module packaging and runtime compatibility. It does not include the performance work tracked in [#118](https://github.com/zuchka/remove-markdown/issues/118), which remains separate so it can be evaluated independently.
+
+## Credits
+
+ESM and Deno support was originally proposed in [#116](https://github.com/zuchka/remove-markdown/pull/116) by [@tukkek](https://github.com/tukkek). The replacement implementation landed in [#119](https://github.com/zuchka/remove-markdown/pull/119), with browser-native ESM hardening in [#122](https://github.com/zuchka/remove-markdown/pull/122).
+
+Thanks to everyone who tested the prereleases and reported compatibility findings before the stable rollout.
+
+## Post-ready announcement
+
+`remove-markdown` 0.7.0 is ready. This release adds native ESM and Deno 2 support while preserving the CommonJS API existing applications already use. It also includes matching TypeScript declarations, explicit package exports, and a self-contained browser ESM build.
+
+We tested the release across Node.js 18–26, Deno, major package managers, TypeScript, browser bundlers, native URL imports, and representative downstream projects. A problem found during the first release candidate was fixed in RC.1 and soaked before promotion, so npm's `latest` users were never exposed to it.
+
+Install or upgrade with:
+
+```sh
+npm install remove-markdown@0.7.0
+```
+
+Full comparison: [0.6.4...0.7.0](https://github.com/zuchka/remove-markdown/compare/0.6.4...0.7.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.7.0] - Unreleased
+## [0.7.0] - 2026-08-31
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remove-markdown",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remove-markdown",
-      "version": "0.7.0-rc.1",
+      "version": "0.7.0",
       "license": "MIT",
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remove-markdown",
-  "version": "0.7.0-rc.1",
+  "version": "0.7.0",
   "description": "Remove Markdown formatting from text",
   "type": "commonjs",
   "main": "./index.js",


### PR DESCRIPTION
## Summary

- promote the soaked `0.7.0-rc.1` package metadata to stable `0.7.0`
- date the 0.7.0 changelog entry for August 31, 2026
- add comprehensive, post-ready release notes at `.github/release-notes/0.7.0.md`

## Soak review

- `0.7.0-rc.1` has been published under `next` since August 26
- no GitHub issues or compatibility PRs were opened during the soak window
- npm `latest` remained on `0.6.4`
- the RC.1 browser-native ESM fix remained publicly installable and verified

## Stable release validation

- confirmed `0.7.0` is available on npm
- synchronized `package.json` and root lockfile metadata
- complete `prepublishOnly` gate
- existing 39-test behavior suite
- CommonJS, ESM, packed-tarball, and TypeScript tests
- Are the Types Wrong validation
- differential comparison with published `0.6.4`
- esbuild and Rollup browser-targeted bundles
- Deno source, HTTP URL-module, and packed npm-package tests
- zero production audit findings
- successful `npm publish --dry-run --tag latest --access public`
- expected eight-file npm tarball; release notes remain repository-only

## Release notes

The included notes provide:

- user-facing highlights and migration expectations
- CommonJS, Node ESM, browser ESM, and Deno examples
- the RC.0 to RC.1 hardening story
- compatibility and validation evidence
- project scope and contributor credit
- concise post-ready announcement copy

## After merge

Publish a non-prerelease GitHub Release tagged `0.7.0` from the merged commit, using `.github/release-notes/0.7.0.md`. The release event will trigger the trusted publishing workflow and move npm's `latest` tag to `0.7.0`.

This PR does not publish the package by itself. Performance issue #118 remains separate.
